### PR TITLE
PVAYLADEV-1047: Fixed wsdl version element namespace

### DIFF
--- a/example-adapter/src/main/resources/example.xroad-6.4.wsdl
+++ b/example-adapter/src/main/resources/example.xroad-6.4.wsdl
@@ -120,7 +120,7 @@
         <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
         <wsdl:operation name="getRandom">
             <soap:operation soapAction="" style="document" />
-            <id:version>v1</id:version>
+            <xrd:version>v1</xrd:version>
             <wsdl:input>
                 <soap:body parts="body" use="literal"/>
                 <soap:header message="tns:requestheader" part="client" use="literal"/>
@@ -143,7 +143,7 @@
 
         <wsdl:operation name="helloService">
             <soap:operation soapAction="" style="document" />
-            <id:version>v1</id:version>
+            <xrd:version>v1</xrd:version>
             <wsdl:input>
                 <soap:body parts="body" use="literal"/>
                 <soap:header message="tns:requestheader" part="client" use="literal"/>


### PR DESCRIPTION
Fixed the `version`-element namespace from `id` to `xrd` as pointed out in issue https://github.com/vrk-kpa/xrd4j/issues/3
