### PR TITLE
#12 Remove wrappers from WSDL file and example messages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ example-adapter/target/
 # IntelliJ Idea
 .idea/
 *.iml
+
+# Other
+.extract/
+xrd-servlet.log

--- a/example-adapter/examples/xroad-6.4/getRandomRequest.xml
+++ b/example-adapter/examples/xroad-6.4/getRandomRequest.xml
@@ -13,14 +13,12 @@
             <iden:subsystemCode>DemoService</iden:subsystemCode>
             <iden:serviceCode>getRandom</iden:serviceCode>
             <iden:serviceVersion>v1</iden:serviceVersion>
-        </xro:service>	  
+        </xro:service>
         <xro:id>ID11234</xro:id>
         <xro:userId>EE1234567890</xro:userId>
         <xro:protocolVersion>4.0</xro:protocolVersion>
     </soapenv:Header>
     <soapenv:Body>
-        <prod:getRandom xmlns:prod="http://test.x-road.fi/producer">
-            <prod:request/>
-        </prod:getRandom>   
+        <prod:getRandom xmlns:prod="http://test.x-road.fi/producer" /> 
     </soapenv:Body>
 </soapenv:Envelope>

--- a/example-adapter/examples/xroad-6.4/getRandomResponse.xml
+++ b/example-adapter/examples/xroad-6.4/getRandomResponse.xml
@@ -20,10 +20,7 @@
     </SOAP-ENV:Header>
     <SOAP-ENV:Body>
         <ts1:getRandomResponse xmlns:ts1="http://test.x-road.fi/producer">
-            <ts1:request/>
-            <ts1:response>
-                <ts1:data>95</ts1:data>
-            </ts1:response>
+            <ts1:data>95</ts1:data>
         </ts1:getRandomResponse>
     </SOAP-ENV:Body>
 </SOAP-ENV:Envelope>

--- a/example-adapter/examples/xroad-6.4/helloServiceRequest.xml
+++ b/example-adapter/examples/xroad-6.4/helloServiceRequest.xml
@@ -13,16 +13,14 @@
             <iden:subsystemCode>DemoService</iden:subsystemCode>
             <iden:serviceCode>helloService</iden:serviceCode>
             <iden:serviceVersion>v1</iden:serviceVersion>
-        </xro:service>        
+        </xro:service>
         <xro:id>ID11234</xro:id>
         <xro:userId>EE1234567890</xro:userId>
         <xro:protocolVersion>4.0</xro:protocolVersion>
     </soapenv:Header>
     <soapenv:Body>
         <prod:helloService xmlns:prod="http://test.x-road.fi/producer">
-            <prod:request>
-                <prod:name>Test</prod:name>
-            </prod:request>
+            <prod:name>Test</prod:name>
         </prod:helloService>
     </soapenv:Body>
 </soapenv:Envelope>

--- a/example-adapter/examples/xroad-6.4/helloServiceResponse.xml
+++ b/example-adapter/examples/xroad-6.4/helloServiceResponse.xml
@@ -20,12 +20,7 @@
     </SOAP-ENV:Header>
     <SOAP-ENV:Body>
         <ts1:helloServiceResponse xmlns:ts1="http://test.x-road.fi/producer">
-            <ts1:request>
-                <ts1:name>Test</ts1:name>
-            </ts1:request>
-            <ts1:response>
-                <ts1:message>Hello Test! Greetings from adapter server!</ts1:message>
-            </ts1:response>
+            <ts1:message>Hello Test! Greetings from adapter server!</ts1:message>
         </ts1:helloServiceResponse>
     </SOAP-ENV:Body>
 </SOAP-ENV:Envelope>

--- a/example-adapter/src/main/resources/example.xroad-6.4.wsdl
+++ b/example-adapter/src/main/resources/example.xroad-6.4.wsdl
@@ -17,20 +17,12 @@
             <xsd:element name="getRandomResponse">
                 <xsd:complexType>
                     <xsd:sequence>
-                        <xsd:element name="request">
-                        </xsd:element>
-                        <xsd:element name="response">
-                            <xsd:complexType>
-                                <xsd:sequence>
-                                    <xsd:element name="data" type="xsd:string">
-                                        <xsd:annotation>
-                                            <xsd:documentation>
-                                                Service response
-                                            </xsd:documentation>
-                                        </xsd:annotation>
-                                    </xsd:element>
-                                </xsd:sequence>
-                            </xsd:complexType>
+                        <xsd:element name="data" type="xsd:string">
+                            <xsd:annotation>
+                                <xsd:documentation>
+                                    Service response
+                                </xsd:documentation>
+                            </xsd:annotation>
                         </xsd:element>
                     </xsd:sequence>
                 </xsd:complexType>
@@ -38,18 +30,12 @@
             <xsd:element name="helloService">
                 <xsd:complexType>
                     <xsd:sequence>
-                        <xsd:element name="request">
-                            <xsd:complexType>
-                                <xsd:sequence>
-                                    <xsd:element name="name" type="xsd:string">
-                                        <xsd:annotation>
-                                            <xsd:documentation>
-                                                Name
-                                            </xsd:documentation>
-                                        </xsd:annotation>
-                                    </xsd:element>
-                                </xsd:sequence>
-                            </xsd:complexType>
+                        <xsd:element name="name" type="xsd:string">
+                            <xsd:annotation>
+                                <xsd:documentation>
+                                    Name
+                                </xsd:documentation>
+                            </xsd:annotation>
                         </xsd:element>
                     </xsd:sequence>
                 </xsd:complexType>
@@ -57,25 +43,12 @@
             <xsd:element name="helloServiceResponse">
                 <xsd:complexType>
                     <xsd:sequence>
-                        <xsd:element name="request">
-                            <xsd:complexType>
-                                <xsd:sequence>
-                                    <xsd:element name="name" nillable="true" type="xsd:string"/>
-                                </xsd:sequence>
-                            </xsd:complexType>
-                        </xsd:element>
-                        <xsd:element name="response">
-                            <xsd:complexType>
-                                <xsd:sequence>
-                                    <xsd:element name="message" type="xsd:string">
-                                        <xsd:annotation>
-                                            <xsd:documentation>
-                                                Service response
-                                            </xsd:documentation>
-                                        </xsd:annotation>
-                                    </xsd:element>
-                                </xsd:sequence>
-                            </xsd:complexType>
+                        <xsd:element name="message" type="xsd:string">
+                            <xsd:annotation>
+                                <xsd:documentation>
+                                    Service response
+                                </xsd:documentation>
+                            </xsd:annotation>
                         </xsd:element>
                     </xsd:sequence>
                 </xsd:complexType>


### PR DESCRIPTION
`<request>` and `<response>` wrappers removed from WSDL file and example messages. Now WSDL and example messages are aligned with the implementation.